### PR TITLE
Disable tests for non-C++11 compilers

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,9 +5,12 @@
 #
 # See http://www.boost.org/libs/poly_collection for library home page.
 
+import testing ;
+import ../../config/checks/config : requires ;
 
 project
     : requirements
+      [ requires cxx11_noexcept ]
       <toolset>msvc:<cxxflags>-D_SCL_SECURE_NO_WARNINGS
     ;
 


### PR DESCRIPTION
Something like that should work, as msvc-12.0 doesn't have `noexcept`. I haven't looked at the code to see what other C++11 features are needed as this one suffices, but you could add more requirements in principle if you feel like it.

Your tests are brutal.