### PR TITLE
Guard assertion about moved-from state of unordered_map

### DIFF
--- a/test/test_construction.cpp
+++ b/test/test_construction.cpp
@@ -123,9 +123,11 @@ void test_allocator_aware_construction()
     rooted_poly_collection p3{root2};
     p3=std::move(p2);
     auto                   d3=get_layout_data<Types...>(p3);
-    if(Propagate||AlwaysEqual)BOOST_TEST(d2==d3);
-    BOOST_TEST(p2.empty());
-    do_((BOOST_TEST(!p2.template is_registered<Types>()),0)...);
+	if (Propagate||AlwaysEqual) {
+		BOOST_TEST(d2 == d3);
+		BOOST_TEST(p2.empty());
+		do_((BOOST_TEST(!p2.template is_registered<Types>()), 0)...);
+	}
 
 #if BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION,<40900)
     /* std::unordered_map move assignment always and only propagates unequal


### PR DESCRIPTION
See discussion in https://github.com/boostorg/poly_collection/issues/11 -- basically, this test wants the moved-from state of an unordered_map to be empty, but there is no such requirement in the standard, and a natural implementation of unordered_map for non-POCMA doesn't empty the assigned-from container.