### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,27 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/poly_collection
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mp11//boost_mp11
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/type_erasure//boost_type_erasure
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_poly_collection ]
+    [ alias all : boost_poly_collection example test ]
+    ;
+
+call-if : boost-library poly_collection
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/poly_collection
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,23 +5,26 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/iterator//boost_iterator
+    /boost/mp11//boost_mp11
+    /boost/mpl//boost_mpl
+    /boost/type_erasure//boost_type_erasure
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/poly_collection
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mp11//boost_mp11
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/type_erasure//boost_type_erasure
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_poly_collection ]
+    [ alias boost_poly_collection : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_poly_collection example test ]
     ;
 
 call-if : boost-library poly_collection
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,14 +7,14 @@ import project ;
 
 project /boost/poly_collection
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mp11//boost_mp11
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/type_erasure//boost_type_erasure
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mp11//boost_mp11
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/type_erasure//boost_type_erasure
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/poly_collection

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -7,6 +7,7 @@
 
 project
     : requirements
+      <library>/boost/poly_collection//boost_poly_collection
       <cxxstd>11
     ;
 

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -7,7 +7,6 @@
 
 project
     : requirements
-      <include>$(BOOST_ROOT)
       <cxxstd>11
     ;
 
@@ -39,6 +38,7 @@ exe insertion_emplacement
 
 exe perf
     : perf.cpp
+      /boost/ptr_container//boost_ptr_container
     :
     : release
     ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import config : requires ;
 
 project
     : requirements
+      <library>/boost/poly_collection//boost_poly_collection
       [ requires cxx11_noexcept ] # used as a proxy for C++11 support
       <toolset>msvc:<cxxflags>-D_SCL_SECURE_NO_WARNINGS
     ;
@@ -22,7 +23,7 @@ test-suite "poly_collection" :
           test_algorithm2.cpp     test_algorithm3.cpp
           test_algorithm_main.cpp
         :
-        :                            
+        :
         : <toolset>msvc:<cxxflags>/bigobj
           <toolset>gcc:<inlining>on
           <toolset>gcc:<optimization>space
@@ -32,7 +33,7 @@ test-suite "poly_collection" :
     [ run test_comparison.cpp     test_comparison_main.cpp   ]
     [ run test_construction.cpp   test_construction_main.cpp
         :
-        :                            
+        :
         : <toolset>msvc:<cxxflags>/bigobj
           <toolset>gcc:<inlining>on
           <toolset>gcc:<optimization>space

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,8 +5,11 @@
 #
 # See http://www.boost.org/libs/poly_collection for library home page.
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project
     : requirements


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.