### PR TITLE
GHA: Fix node issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:


### PR DESCRIPTION
Github Actions will force the use of node20 which doesn't work in the containers. This env variable extends the period where node16 is usable