### PR TITLE
SFINAEd `fixed_variant` relational operators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:
@@ -177,10 +178,13 @@ jobs:
             install: clang-18
           - toolset: clang
             cxxstd: "11,14,17,20,2b"
-            os: macos-13
-          - toolset: clang
-            cxxstd: "11,14,17,20,2b"
             os: macos-14
+          - toolset: clang
+            cxxstd: "11,14,17,20,23,2c"
+            os: macos-15
+          - toolset: clang
+            cxxstd: "11,14,17,20,23,2c"
+            os: macos-26
 
     runs-on: ${{matrix.os}}
     container:
@@ -295,3 +299,4 @@ jobs:
         run: |
           cd ../boost-root
           b2 -j3 libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} variant=debug,release embed-manifest-via=linker
+

--- a/doc/poly_collection.qbk
+++ b/doc/poly_collection.qbk
@@ -1,7 +1,7 @@
 [library Boost.PolyCollection
   [quickbook 1.6]
   [authors [López Muñoz, Joaquín M]]
-  [copyright 2016-2025 Joaquín M López Muñoz]
+  [copyright 2016-2026 Joaquín M López Muñoz]
   [category containers]
   [id poly_collection]
   [dirname poly_collection]
@@ -1203,6 +1203,15 @@ to allow for the definition of container-level `operator<` and related operators
 [endsect]
 
 [section Release notes]
+
+[section Boost 1.92]
+
+* Made [' `variant_collection_value_type_impl`]`<Ts...>`'s relational operators available
+only when the corresponding relational operator is available for all `Ts...`, in
+accordance with WG21 paper
+[@https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2944r3.html P2944R3].
+
+[endsect]
 
 [section Boost 1.88]
 

--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -1416,6 +1416,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()==std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()==y.index()&&get<I>(x)==get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.operator_ne]
@@ -1425,6 +1427,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()!=std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()!=y.index()||get<I>(x)!=get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.operator_lt]
@@ -1434,6 +1438,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()<std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()<y.index()||x.index()==y.index()&&get<I>(x)<get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.operator_gt]
@@ -1443,6 +1449,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()>std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()>y.index()||x.index()==y.index()&&get<I>(x)>get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.operator_le]
@@ -1452,6 +1460,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()<=std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()<y.index()||x.index()==y.index()&&get<I>(x)<=get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.operator_ge]
@@ -1461,6 +1471,8 @@ a pointer to the contained value otherwise.
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& x,`[br]
 [^ \u00a0\u00a0]`const `[^ /variant_collection_value_type_impl/]`<Ts...>& y);`
 
+[*Constraints:]  `std::declval<const Ti&>()>=std::declval<const Ti&>()` is a valid expression
+convertible to `bool` for all `Ti` in `Ts...`.[br]
 [*Returns:] `x.index()>y.index()||x.index()==y.index()&&get<I>(x)>=get<I>(y)` with `I==x.index()`.
 
 [#poly_collection.reference.header_boost_poly_collection_va0.alias_template_variant_collectio.visit]

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024-2025 Joaquin M Lopez Munoz.
+/* Copyright 2024-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -505,13 +505,25 @@ struct relop_helper
   }
 };
 
+template<template<typename> class Expr,typename... Ts>
+using all_support=mp11::mp_all<mp11::mp_valid<Expr,Ts>...>;
+
+void convertible_to_bool(bool);
+
 struct eq_
 {
   template<typename T>
   bool operator()(const T& x,const T& y)const{return x==y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using eq_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()==std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<eq_expr,Ts...>::value>::type* =nullptr
+>
 bool operator==(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
@@ -526,7 +538,14 @@ struct neq_
   bool operator()(const T& x,const T& y)const{return x!=y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using neq_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()!=std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<neq_expr,Ts...>::value>::type* =nullptr
+>
 bool operator!=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
@@ -542,7 +561,14 @@ struct lt_
   bool operator()(const T& x,const T& y)const{return x<y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using lt_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()<std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<lt_expr,Ts...>::value>::type* =nullptr
+>
 bool operator<(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
@@ -558,7 +584,14 @@ struct lte_
   bool operator()(const T& x,const T& y)const{return x<=y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using lte_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()<=std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<lte_expr,Ts...>::value>::type* =nullptr
+>
 bool operator<=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
@@ -574,7 +607,14 @@ struct gt_
   bool operator()(const T& x,const T& y)const{return x>y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using gt_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()>std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<gt_expr,Ts...>::value>::type* =nullptr
+>
 bool operator>(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
@@ -590,7 +630,14 @@ struct gte_
   bool operator()(const T& x,const T& y)const{return x>=y;}
 };
 
-template<typename... Ts>
+template<typename T>
+using gte_expr=decltype(
+  convertible_to_bool(std::declval<const T&>()>=std::declval<const T&>()));
+
+template<
+  typename... Ts,
+  typename std::enable_if<all_support<gte_expr,Ts...>::value>::type* =nullptr
+>
 bool operator>=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -518,11 +518,14 @@ struct eq_
 
 template<typename T>
 using eq_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()==std::declval<const T&>()));
+  std::declval<const T&>()==std::declval<const T&>());
 
-template<typename... Ts>
-typename std::enable_if<all_valid<eq_expr,Ts...>::value,bool>::type
-operator==(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<eq_expr,Ts...>::value>::type* =nullptr
+>
+bool operator==(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()==y.index()&&
@@ -537,11 +540,14 @@ struct neq_
 
 template<typename T>
 using neq_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()!=std::declval<const T&>()));
+  std::declval<const T&>()!=std::declval<const T&>());
 
-template<typename... Ts>
-typename std::enable_if<all_valid<neq_expr,Ts...>::value,bool>::type
-operator!=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<neq_expr,Ts...>::value>::type* =nullptr
+>
+bool operator!=(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()!=y.index()||
@@ -557,11 +563,14 @@ struct lt_
 
 template<typename T>
 using lt_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()<std::declval<const T&>()));
+  std::declval<const T&>()<std::declval<const T&>());
 
-template<typename... Ts>
-typename std::enable_if<all_valid<lt_expr,Ts...>::value,bool>::type
-operator<(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<lt_expr,Ts...>::value>::type* =nullptr
+>
+bool operator<(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()<y.index()||
@@ -577,11 +586,14 @@ struct lte_
 
 template<typename T>
 using lte_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()<=std::declval<const T&>()));
+  std::declval<const T&>()<=std::declval<const T&>());
 
-template<typename... Ts>
-typename std::enable_if<all_valid<lte_expr,Ts...>::value,bool>::type
-operator<=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<lte_expr,Ts...>::value>::type* =nullptr
+>
+bool operator<=(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()<y.index()||
@@ -597,11 +609,14 @@ struct gt_
 
 template<typename T>
 using gt_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()>std::declval<const T&>()));
+  std::declval<const T&>()>std::declval<const T&>());
 
-template<typename... Ts>
-typename std::enable_if<all_valid<gt_expr,Ts...>::value,bool>::type
-operator>(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<gt_expr,Ts...>::value>::type* =nullptr
+>
+bool operator>(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()>y.index()||
@@ -617,11 +632,14 @@ struct gte_
 
 template<typename T>
 using gte_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()>=std::declval<const T&>()));
+  std::declval<const T&>()>=std::declval<const T&>());
 
-template<typename... Ts>  
-typename std::enable_if<all_valid<gte_expr,Ts...>::value,bool>::type
-operator>=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<
+  typename... Ts,
+  typename std::enable_if<all_valid<gte_expr,Ts...>::value>::type* =nullptr
+>
+bool operator>=(
+  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()>y.index()||

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -505,8 +505,20 @@ struct relop_helper
   }
 };
 
+template<typename...>
+struct make_void{typedef void type;};
+template<typename... Ts> using void_t=typename make_void<Ts...>::type;
+
+template<class, template<typename...> class F,typename... T>
+struct mp_valid_impl:std::false_type{};
+template<template<typename...> class F,typename... T>
+struct mp_valid_impl<void_t<F<T...>>,F,T...>:std::true_type{};
+
+template<template<class...> class F,class... T> using mp_valid=
+  typename mp_valid_impl<void, F, T...>;
+
 template<template<typename> class Expr,typename... Ts>
-using all_valid=mp11::mp_all<mp11::mp_valid<Expr,Ts>...>;
+using all_valid=mp11::mp_all<mp_valid<Expr,Ts>...>;
 
 void convertible_to_bool(bool);
 
@@ -518,7 +530,7 @@ struct eq_
 
 template<typename T>
 using eq_expr=decltype(
-  std::declval<const T&>()==std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()==std::declval<const T&>()));
 
 template<
   typename... Ts,
@@ -540,7 +552,7 @@ struct neq_
 
 template<typename T>
 using neq_expr=decltype(
-  std::declval<const T&>()!=std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()!=std::declval<const T&>()));
 
 template<
   typename... Ts,
@@ -563,7 +575,7 @@ struct lt_
 
 template<typename T>
 using lt_expr=decltype(
-  std::declval<const T&>()<std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()<std::declval<const T&>()));
 
 template<
   typename... Ts,
@@ -586,7 +598,7 @@ struct lte_
 
 template<typename T>
 using lte_expr=decltype(
-  std::declval<const T&>()<=std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()<=std::declval<const T&>()));
 
 template<
   typename... Ts,
@@ -609,7 +621,7 @@ struct gt_
 
 template<typename T>
 using gt_expr=decltype(
-  std::declval<const T&>()>std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()>std::declval<const T&>()));
 
 template<
   typename... Ts,
@@ -632,7 +644,7 @@ struct gte_
 
 template<typename T>
 using gte_expr=decltype(
-  std::declval<const T&>()>=std::declval<const T&>());
+  convertible_to_bool(std::declval<const T&>()>=std::declval<const T&>()));
 
 template<
   typename... Ts,

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -520,12 +520,9 @@ template<typename T>
 using eq_expr=decltype(
   convertible_to_bool(std::declval<const T&>()==std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<eq_expr,Ts...>::value>::type* =nullptr
->
-bool operator==(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>
+typename std::enable_if<all_valid<eq_expr,Ts...>::value,bool>::type
+operator==(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()==y.index()&&
@@ -542,12 +539,9 @@ template<typename T>
 using neq_expr=decltype(
   convertible_to_bool(std::declval<const T&>()!=std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<neq_expr,Ts...>::value>::type* =nullptr
->
-bool operator!=(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>
+typename std::enable_if<all_valid<neq_expr,Ts...>::value,bool>::type
+operator!=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()!=y.index()||
@@ -565,12 +559,9 @@ template<typename T>
 using lt_expr=decltype(
   convertible_to_bool(std::declval<const T&>()<std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<lt_expr,Ts...>::value>::type* =nullptr
->
-bool operator<(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>
+typename std::enable_if<all_valid<lt_expr,Ts...>::value,bool>::type
+operator<(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()<y.index()||
@@ -588,12 +579,9 @@ template<typename T>
 using lte_expr=decltype(
   convertible_to_bool(std::declval<const T&>()<=std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<lte_expr,Ts...>::value>::type* =nullptr
->
-bool operator<=(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>
+typename std::enable_if<all_valid<lte_expr,Ts...>::value,bool>::type
+operator<=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()<y.index()||
@@ -611,12 +599,9 @@ template<typename T>
 using gt_expr=decltype(
   convertible_to_bool(std::declval<const T&>()>std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<gt_expr,Ts...>::value>::type* =nullptr
->
-bool operator>(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>
+typename std::enable_if<all_valid<gt_expr,Ts...>::value,bool>::type
+operator>(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()>y.index()||
@@ -634,12 +619,9 @@ template<typename T>
 using gte_expr=decltype(
   convertible_to_bool(std::declval<const T&>()>=std::declval<const T&>()));
 
-template<
-  typename... Ts,
-  typename std::enable_if<all_valid<gte_expr,Ts...>::value>::type* =nullptr
->
-bool operator>=(
-  const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
+template<typename... Ts>  
+typename std::enable_if<all_valid<gte_expr,Ts...>::value,bool>::type
+operator>=(const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
 {
   return
     x.index()>y.index()||

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -515,7 +515,7 @@ template<template<typename...> class F,typename... T>
 struct mp_valid_impl<void_t<F<T...>>,F,T...>:std::true_type{};
 
 template<template<class...> class F,class... T> using mp_valid=
-  typename mp_valid_impl<void, F, T...>;
+  typename mp_valid_impl<void, F, T...>::type;
 
 template<template<typename> class Expr,typename... Ts>
 using all_valid=mp11::mp_all<mp_valid<Expr,Ts>...>;

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -24,6 +24,12 @@
 #include <boost/mp11/utility.hpp>
 #include <boost/poly_collection/detail/is_equality_comparable.hpp>
 #include <boost/poly_collection/detail/is_nothrow_eq_comparable.hpp>
+#include <boost/type_traits/has_equal_to.hpp>
+#include <boost/type_traits/has_greater.hpp>
+#include <boost/type_traits/has_greater_equal.hpp>
+#include <boost/type_traits/has_less.hpp>
+#include <boost/type_traits/has_less_equal.hpp>
+#include <boost/type_traits/has_not_equal_to.hpp>
 #include <boost/type_traits/is_constructible.hpp>
 #include <cstddef>
 #include <limits>
@@ -505,23 +511,6 @@ struct relop_helper
   }
 };
 
-template<typename...>
-struct make_void{typedef void type;};
-template<typename... Ts> using void_t=typename make_void<Ts...>::type;
-
-template<class, template<typename...> class F,typename... T>
-struct mp_valid_impl:std::false_type{};
-template<template<typename...> class F,typename... T>
-struct mp_valid_impl<void_t<F<T...>>,F,T...>:std::true_type{};
-
-template<template<class...> class F,class... T> using mp_valid=
-  typename mp_valid_impl<void, F, T...>::type;
-
-template<template<typename> class Expr,typename... Ts>
-using all_valid=mp11::mp_all<mp_valid<Expr,Ts>...>;
-
-void convertible_to_bool(bool);
-
 struct eq_
 {
   template<typename T>
@@ -529,12 +518,11 @@ struct eq_
 };
 
 template<typename T>
-using eq_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()==std::declval<const T&>()));
+using eq_expr=has_equal_to<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<eq_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<eq_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator==(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -551,12 +539,11 @@ struct neq_
 };
 
 template<typename T>
-using neq_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()!=std::declval<const T&>()));
+using neq_expr=has_not_equal_to<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<neq_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<neq_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator!=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -574,12 +561,11 @@ struct lt_
 };
 
 template<typename T>
-using lt_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()<std::declval<const T&>()));
+using lt_expr=has_less<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<lt_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<lt_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator<(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -597,12 +583,11 @@ struct lte_
 };
 
 template<typename T>
-using lte_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()<=std::declval<const T&>()));
+using lte_expr=has_less_equal<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<lte_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<lte_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator<=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -620,12 +605,11 @@ struct gt_
 };
 
 template<typename T>
-using gt_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()>std::declval<const T&>()));
+using gt_expr=has_greater<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<gt_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<gt_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator>(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -643,12 +627,11 @@ struct gte_
 };
 
 template<typename T>
-using gte_expr=decltype(
-  convertible_to_bool(std::declval<const T&>()>=std::declval<const T&>()));
+using gte_expr=has_greater_equal<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<all_valid<gte_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<mp11::mp_all<gte_expr<Ts>...>::value>::type* =nullptr
 >
 bool operator>=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -518,11 +518,12 @@ struct eq_
 };
 
 template<typename T>
-using eq_expr=has_equal_to<T,T,bool>;
+using eq_constraint=has_equal_to<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<eq_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<eq_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator==(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -539,11 +540,12 @@ struct neq_
 };
 
 template<typename T>
-using neq_expr=has_not_equal_to<T,T,bool>;
+using neq_constraint=has_not_equal_to<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<neq_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<neq_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator!=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -561,11 +563,12 @@ struct lt_
 };
 
 template<typename T>
-using lt_expr=has_less<T,T,bool>;
+using lt_constraint=has_less<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<lt_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<lt_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator<(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -583,11 +586,12 @@ struct lte_
 };
 
 template<typename T>
-using lte_expr=has_less_equal<T,T,bool>;
+using lte_constraint=has_less_equal<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<lte_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<lte_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator<=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -605,11 +609,12 @@ struct gt_
 };
 
 template<typename T>
-using gt_expr=has_greater<T,T,bool>;
+using gt_constraint=has_greater<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<gt_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<gt_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator>(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -627,11 +632,12 @@ struct gte_
 };
 
 template<typename T>
-using gte_expr=has_greater_equal<T,T,bool>;
+using gte_constraint=has_greater_equal<T,T,bool>;
 
 template<
   typename... Ts,
-  typename std::enable_if<mp11::mp_all<gte_expr<Ts>...>::value>::type* =nullptr
+  typename std::enable_if<
+    mp11::mp_all<gte_constraint<Ts>...>::value>::type* =nullptr
 >
 bool operator>=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)

--- a/include/boost/poly_collection/detail/fixed_variant.hpp
+++ b/include/boost/poly_collection/detail/fixed_variant.hpp
@@ -506,7 +506,7 @@ struct relop_helper
 };
 
 template<template<typename> class Expr,typename... Ts>
-using all_support=mp11::mp_all<mp11::mp_valid<Expr,Ts>...>;
+using all_valid=mp11::mp_all<mp11::mp_valid<Expr,Ts>...>;
 
 void convertible_to_bool(bool);
 
@@ -522,7 +522,7 @@ using eq_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<eq_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<eq_expr,Ts...>::value>::type* =nullptr
 >
 bool operator==(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -544,7 +544,7 @@ using neq_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<neq_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<neq_expr,Ts...>::value>::type* =nullptr
 >
 bool operator!=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -567,7 +567,7 @@ using lt_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<lt_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<lt_expr,Ts...>::value>::type* =nullptr
 >
 bool operator<(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -590,7 +590,7 @@ using lte_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<lte_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<lte_expr,Ts...>::value>::type* =nullptr
 >
 bool operator<=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -613,7 +613,7 @@ using gt_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<gt_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<gt_expr,Ts...>::value>::type* =nullptr
 >
 bool operator>(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)
@@ -636,7 +636,7 @@ using gte_expr=decltype(
 
 template<
   typename... Ts,
-  typename std::enable_if<all_support<gte_expr,Ts...>::value>::type* =nullptr
+  typename std::enable_if<all_valid<gte_expr,Ts...>::value>::type* =nullptr
 >
 bool operator>=(
   const fixed_variant<Ts...>& x,const fixed_variant<Ts...>& y)


### PR DESCRIPTION
In line with [P2944R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2944r3.html). Fixes a regression in Clang with `-std=c++2c -stdlib=libc++` analogous to the one described at https://github.com/boostorg/variant2/issues/60.