### PR TITLE
used library feature-test macros for `std::is_(final|invocable)` detection

### DIFF
--- a/doc/poly_collection.qbk
+++ b/doc/poly_collection.qbk
@@ -1210,6 +1210,7 @@ to allow for the definition of container-level `operator<` and related operators
 only when the corresponding relational operator is available for all `Ts...`, in
 accordance with WG21 paper
 [@https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2944r3.html P2944R3].
+* Fixed incompatibility problem with libc++ v21 or higher ([github_pr poly_collection 34]).
 
 [endsect]
 

--- a/include/boost/poly_collection/detail/is_final.hpp
+++ b/include/boost/poly_collection/detail/is_final.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2017 Joaquin M Lopez Munoz.
+/* Copyright 2016-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
@@ -13,56 +13,37 @@
 #pragma once
 #endif
 
-#include <boost/type_traits/is_final.hpp>
 #include <type_traits>
 
-/* technique explained at
- * http://bannalia.blogspot.com/2016/09/compile-time-checking-existence-of.html 
- */
-
-namespace boost{
-namespace poly_collection{
-namespace detail{
-namespace is_final_fallback{
-
-template<typename T> using is_final=boost::is_final<T>;
-
-struct hook{};
-
-}}}}
-
-namespace std{
-
-template<>
-struct is_void< ::boost::poly_collection::detail::is_final_fallback::hook>:
-  std::false_type
-{      
-  template<typename T>
-  static constexpr bool is_final_f()
-  {
-    using namespace ::boost::poly_collection::detail::is_final_fallback;
-    return is_final<T>::value;
-  }
-};
-
-} /* namespace std */
-
+#if __cpp_lib_is_final>=201402L
 namespace boost{
 
 namespace poly_collection{
 
 namespace detail{
 
-template<typename T>
-struct is_final:std::integral_constant<
-  bool,
-  std::is_void<is_final_fallback::hook>::template is_final_f<T>()
->{};
+template<typename T> using is_final=std::is_final<T>;
 
 } /* namespace poly_collection::detail */
 
 } /* namespace poly_collection */
 
 } /* namespace boost */
+#else
+#include <boost/type_traits/is_final.hpp>
 
+namespace boost{
+
+namespace poly_collection{
+
+namespace detail{
+
+template<typename T> using is_final=boost::is_final<T>;
+
+} /* namespace poly_collection::detail */
+
+} /* namespace poly_collection */
+
+} /* namespace boost */
+#endif
 #endif

--- a/include/boost/poly_collection/detail/is_final.hpp
+++ b/include/boost/poly_collection/detail/is_final.hpp
@@ -46,4 +46,5 @@ template<typename T> using is_final=boost::is_final<T>;
 
 } /* namespace boost */
 #endif
+
 #endif

--- a/include/boost/poly_collection/detail/is_invocable.hpp
+++ b/include/boost/poly_collection/detail/is_invocable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2017 Joaquin M Lopez Munoz.
+/* Copyright 2016-2026 Joaquin M Lopez Munoz.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/poly_collection/detail/is_invocable.hpp
+++ b/include/boost/poly_collection/detail/is_invocable.hpp
@@ -13,17 +13,34 @@
 #pragma once
 #endif
 
-#include <functional>
 #include <type_traits>
 
-/* technique explained at
- * http://bannalia.blogspot.com/2016/09/compile-time-checking-existence-of.html 
- */
+#if __cpp_lib_is_invocable>=201703L
+namespace boost{
+
+namespace poly_collection{
+
+namespace detail{
+
+template <typename F,typename... Args>
+using is_invocable=std::is_invocable<F,Args...>;
+
+template <typename R,typename F,typename... Args>
+using is_invocable_r=std::is_invocable_r<R,F,Args...>;
+
+} /* namespace poly_collection::detail */
+
+} /* namespace poly_collection */
+
+} /* namespace boost */
+#else
+#include <functional>
 
 namespace boost{
+
 namespace poly_collection{
+
 namespace detail{
-namespace is_invocable_fallback{
 
 template <typename F,typename... Args>
 struct is_invocable:
@@ -41,57 +58,11 @@ struct is_invocable_r:
   >
 {};
 
-struct hook{};
-
-}}}}
-
-namespace std{
-
-template<>
-struct is_void< ::boost::poly_collection::detail::is_invocable_fallback::hook>:
-  std::false_type
-{      
-  template<typename F,typename... Args>
-  static constexpr bool is_invocable_f()
-  {
-    using namespace ::boost::poly_collection::detail::is_invocable_fallback;
-    return is_invocable<F,Args...>::value;
-  }
-
-  template<typename R,typename F,typename... Args>
-  static constexpr bool is_invocable_r_f()
-  {
-    using namespace ::boost::poly_collection::detail::is_invocable_fallback;
-    return is_invocable_r<R,F,Args...>::value;
-  }
-};
-
-} /* namespace std */
-
-namespace boost{
-
-namespace poly_collection{
-
-namespace detail{
-
-template<typename F,typename... Args>
-struct is_invocable:std::integral_constant<
-  bool,
-  std::is_void<is_invocable_fallback::hook>::template
-    is_invocable_f<F,Args...>()
->{};
-
-template<typename R,typename F,typename... Args>
-struct is_invocable_r:std::integral_constant<
-  bool,
-  std::is_void<is_invocable_fallback::hook>::template
-    is_invocable_r_f<R,F,Args...>()
->{};
-
 } /* namespace poly_collection::detail */
 
 } /* namespace poly_collection */
 
 } /* namespace boost */
+#endif
 
 #endif


### PR DESCRIPTION
[Former detection technique](http://bannalia.blogspot.com/2016/09/compile-time-checking-existence-of.html) was flagged by libc++ v21 (`std::void` not user-specializable). The technique could have been kept by making it rely on say `std::hash`,  but using feature macros was deemed simpler.